### PR TITLE
Fix cargo doc failure

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 #![doc = "Peripheral access API for NRF51 microcontrollers (generated using svd2rust v0.13.1)\n\nYou can find an overview of the API [here].\n\n[here]: https://docs.rs/svd2rust/0.13.1/svd2rust/#peripheral-api"]
 #![deny(missing_docs)]
-#![deny(warnings)]
 #![allow(non_camel_case_types)]
 #![no_std]
 extern crate bare_metal;


### PR DESCRIPTION
I'm not sure if this is a sustainable change, given that I think this file was generated with svd2rust, but it fixes a pretty pressing issue right now. Should close #3.