### PR TITLE
Provide memory.x linker scripts based on a chip variant feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,6 @@ version = "0.6.10"
 [features]
 default = ["rt"]
 rt = ["cortex-m-rt/device"]
+memory-aa = []
+memory-ab = []
+memory-ac = []

--- a/README.md
+++ b/README.md
@@ -10,6 +10,17 @@ The register definitions were created from the collection of CMSIS SVD files at
 [cmsis-svd]: https://github.com/posborne/cmsis-svd.git
 [svd2rust]: https://github.com/japaric/svd2rust
 
+`memory.x`
+------------
+
+This crate can provide the linker with the locations and sizes of flash and RAM, as long as the relevant chip-variant feature is enabled:
+
+| Feature     | Flash | RAM  |
+|-------------|-------|------|
+| `memory-aa` | 256KB | 16KB |
+| `memory-ab` | 128KB | 16KB |
+| `memory-ac` | 256KB | 32KB |
+
 License
 -------
 

--- a/build.rs
+++ b/build.rs
@@ -2,6 +2,7 @@ use std::env;
 use std::fs::File;
 use std::io::Write;
 use std::path::PathBuf;
+
 fn main() {
     if env::var_os("CARGO_FEATURE_RT").is_some() {
         let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
@@ -12,5 +13,35 @@ fn main() {
         println!("cargo:rustc-link-search={}", out.display());
         println!("cargo:rerun-if-changed=device.x");
     }
+
+    if let Some((flash, mem)) = memory_sizes() {
+        let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
+
+        let mut file = File::create(out.join("memory.x")).unwrap();
+
+        write!(file, r#"MEMORY
+{{
+FLASH : ORIGIN = 0x00000000, LENGTH = {}
+RAM : ORIGIN = 0x20000000, LENGTH = {}
+}}
+"#, flash, mem).unwrap();
+
+        println!("cargo:rustc-link-search={}", out.display());
+    }
+
     println!("cargo:rerun-if-changed=build.rs");
+}
+
+fn memory_sizes() -> Option<(&'static str, &'static str)> {
+    let aa = env::var_os("CARGO_FEATURE_MEMORY_AA").is_some();
+    let ab = env::var_os("CARGO_FEATURE_MEMORY_AB").is_some();
+    let ac = env::var_os("CARGO_FEATURE_MEMORY_AC").is_some();
+
+    match (aa, ab, ac) {
+        (false, false, false) => None,
+        (true, false, false) => Some(("256K", "16K")),
+        (false, true, false) => Some(("128K", "16K")),
+        (false, false, true) => Some(("256K", "32K")),
+        _ => panic!("Multiple memory configuration features specified"),
+    }
 }


### PR DESCRIPTION
For consistency with the nrf52-series PACs, I thought it would be useful to provide linker scripts for memory configuration. Obviously this crate targets multiple chips, so I landed on feature flags to specify which chip variant (AA, AB, or AC) the user is targeting. If no feature is specified (the default), the crate behaves as before.

The variant codes and memory layouts are the same across the 51422 and 51822 chips, so hopefully this covers everything the crate targets.